### PR TITLE
REM: save_to_disk in examples

### DIFF
--- a/examples/example_01_cheese_3D.py
+++ b/examples/example_01_cheese_3D.py
@@ -10,11 +10,9 @@ import torch
 import numpy as np
 from gudhi import AlphaComplex, SimplexTree
 
-from flooder import generate_swiss_cheese_points, flood_complex, save_to_disk
+from flooder import generate_swiss_cheese_points, flood_complex
 
 DEVICE = torch.device("cuda")
-OUT_DIR = "/tmp/"
-OUT_FILE = "flooder_cheese_timing_for_varying_number_of_points.pt"
 
 # Custom colors for terminal output
 RED = "\033[91m"
@@ -94,20 +92,6 @@ def main():
 
             pdiagram_land2 = st.persistence_intervals_in_dimension(dim - 1)
             pdiagram_land_flood_s.append(pdiagram_land2)
-
-    save_to_disk(
-        {
-            "results": results,
-            "pdiagram_land_flood_s": pdiagram_land_flood_s,
-            "pdiagram_land_alpha_s": pdiagram_land_alpha_s,
-            "n_ws": n_ws,
-            "n_l": n_l,
-            "b_sizes": b_sizes,
-            "rect_min": rect_min.cpu().numpy(),
-            "rect_max": rect_max.cpu().numpy(),
-        },
-        "/tmp/example_01_cheese_3D_out.pt",
-    )
 
 
 if __name__ == "__main__":

--- a/examples/example_02_torus_3D.py
+++ b/examples/example_02_torus_3D.py
@@ -8,16 +8,9 @@ import time
 import torch
 import gudhi
 
-from flooder import (
-    generate_noisy_torus_points,
-    flood_complex,
-    generate_landmarks,
-    save_to_disk,
-)
+from flooder import generate_noisy_torus_points, flood_complex, generate_landmarks
 
 
-OUT_DIR = "/tmp/"
-OUT_FILE = "flooder_example_02_torus_3D_diagrams.pt"
 DEVICE = torch.device("cuda")
 
 RED = "\033[91m"
@@ -30,7 +23,7 @@ def main():
     print(f"{YELLOW}Flood PH of a noisy torus sample (1M points)")
     print(f"{YELLOW}--------------------------------------------")
     for i in range(3):
-        N_w = 10000  # Number of points sampled from torus
+        N_w = 1_000_000  # Number of points sampled from torus
         N_l = 2000  # Number of landmarks for Flood complex
 
         pts = generate_noisy_torus_points(N_w)
@@ -61,16 +54,6 @@ def main():
         )
 
         diags = [st.persistence_intervals_in_dimension(d) for d in range(3)]
-
-    save_to_disk(
-        {
-            "pts": pts.cpu().numpy(),
-            "lms": lms.cpu().numpy(),
-            "complex": out_complex,
-            "diags": diags,
-        },
-        "/tmp/example_02_torus_3D_out.pt",
-    )
 
 
 if __name__ == "__main__":

--- a/examples/example_03_figure_eight_2D.py
+++ b/examples/example_03_figure_eight_2D.py
@@ -9,12 +9,7 @@ import gudhi
 import torch
 import numpy as np
 
-from flooder import (
-    generate_landmarks,
-    flood_complex,
-    generate_figure_eight_2D_points,
-    save_to_disk,
-)
+from flooder import generate_landmarks, flood_complex, generate_figure_eight_2D_points
 
 device = torch.device("cuda")
 
@@ -54,9 +49,7 @@ def main():
     print(f"{YELLOW}Flood PH of a noisy figure-eight sample 40M points)")
     print(f"{YELLOW}---------------------------------------------------")
 
-    pts = generate_figure_eight_2D_points(
-        N_w, noise_std=0.02, noise_kind="gaussian", rng=42
-    )
+    pts = generate_figure_eight_2D_points(N_w, noise_std=0.02, noise_kind="gaussian")
 
     t0_fps = time.perf_counter()
     lms = generate_landmarks(pts, N_l)
@@ -93,18 +86,6 @@ def main():
                 f"{BLUE}  {j + 1:2d}: (birth, death)=({b:.4f}, {d:.4f}), lifetime={(d - b):.4f} {RESET}"
             )
 
-    # Save the output to disk
-    save_to_disk(
-        {
-            "pts": pts.cpu().numpy(),
-            "lms": lms.cpu().numpy(),
-            "complex": out_complex,
-            "diags": diags,
-        },
-        "/tmp/example_03_figure_eight_2D_out.pt",
-        True,
-        True,
-    )
     print(
         f"{RED}Peak memory: {torch.cuda.max_memory_allocated() / 1024**2} MiB {RESET}"
     )

--- a/flooder/core.py
+++ b/flooder/core.py
@@ -88,7 +88,7 @@ def flood_complex(
             Either an integer indicating the number of landmarks to randomly sample from `points`, or a tensor of shape (N_l, d) specifying explicit landmark coordinates.
         points (torch.Tensor):
             A (N, d) tensor containing witness points used as sources in the flood process.
-        dim (Union[None, int], optional):
+        max_dimension (Union[None, int], optional):
             The top dimension of the simplices to construct.
             Defaults to None resulting in the dimension of the ambient space.
         points_per_edge (Union[None, int], optional):

--- a/flooder/synthetic_data_generators.py
+++ b/flooder/synthetic_data_generators.py
@@ -33,13 +33,10 @@ def generate_figure_eight_2D_points(
             (for uniform) of noise to add to each point. Defaults to 0.0 (no noise).
         noise_kind (Literal["gaussian", "uniform"], optional): Type of noise distribution
             to use if `noise_std > 0`. Defaults to "gaussian".
-        rng (Optional[np.random.Generator], optional): Optional NumPy random number
-            generator for reproducibility. If None, a new default generator is used.
 
     Returns:
         torch.Tensor: A tensor of shape (n_samples, 2) containing the sampled 2D points.
     """
-    # rng = np.random.default_rng(rng)
 
     lobe_idx = np.random.randint(0, 2, size=n_samples)
     cx, cy = np.asarray(centers).T  # shape (2,)


### PR DESCRIPTION
Remove save_to_disk dependency in examples and cleanup of parameter naming in Google docstrings.