### PR TITLE
Speed up creation of gudhi simplex tree

### DIFF
--- a/flooder/core.py
+++ b/flooder/core.py
@@ -93,13 +93,13 @@ def flood_complex(
     else:
         kdtree = KDTree(np.asarray(points))
 
-    dc = gudhi.DelaunayComplex(  # pylint: disable=no-member
+    stree = gudhi.DelaunayComplex(  # pylint: disable=no-member
         landmarks
     ).create_simplex_tree()
     out_complex = {}
 
     simplices = [[] for _ in range(max_dimension + 1)]
-    for simplex, _ in dc.get_simplices():
+    for simplex, _ in stree.get_simplices():
         if len(simplex) <= max_dimension + 1:
             simplices[len(simplex) - 1].append(tuple(simplex))
 
@@ -238,9 +238,7 @@ def flood_complex(
                     zip(map(tuple, d_simplices[start:end].tolist()), min_covering_radius.tolist())
                 )
 
-    stree = gudhi.SimplexTree()  # pylint: disable=no-member
     for simplex, filtration_val in out_complex.items():
-        stree.insert(simplex, float("inf"))
         stree.assign_filtration(simplex, filtration_val)
     stree.make_filtration_non_decreasing()
     if return_simplex_tree:

--- a/flooder/core.py
+++ b/flooder/core.py
@@ -12,6 +12,7 @@ import torch
 import gudhi
 import fpsample
 import numpy as np
+from numbers import Integral
 from scipy.spatial import KDTree
 
 from .triton_kernels import compute_mask, compute_filtration
@@ -79,8 +80,7 @@ def flood_complex(
     """
     if max_dimension is None:
         max_dimension = points.shape[1]
-
-    if isinstance(landmarks, int):
+    if isinstance(landmarks, Integral):
         landmarks = generate_landmarks(
             points, min(landmarks, points.shape[0]), fps_h, start_idx=start_idx
         )
@@ -358,7 +358,7 @@ def generate_grid(
             vertex_idxs_k.append(idx)
         face_idxs.append(torch.stack(face_idxs_k))
         vertex_idxs.append(torch.stack(vertex_idxs_k))
-    grid = grid / (n -1)
+    grid = grid / (n - 1)
     return grid, vertex_idxs, face_idxs
 
 

--- a/flooder/core.py
+++ b/flooder/core.py
@@ -235,7 +235,7 @@ def flood_complex(
             else:
                 min_covering_radius = torch.amax(distances, dim=1)
                 out_complex.update(
-                    zip(d_simplices[start:end], min_covering_radius.tolist())
+                    zip(map(tuple, d_simplices[start:end].tolist()), min_covering_radius.tolist())
                 )
 
     stree = gudhi.SimplexTree()  # pylint: disable=no-member

--- a/tests/test_flooder.py
+++ b/tests/test_flooder.py
@@ -23,7 +23,7 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 @pytest.mark.parametrize("use_triton", [True, False])
 @pytest.mark.parametrize("batch_size", [8, 23])
 @pytest.mark.parametrize("use_rand", [True, False])
-def test_vs_alpha_1(use_triton, batch_size, use_rand):
+def test_vs_alpha(use_triton, batch_size, use_rand):
     """
     Test the homotopy equivalence of the Alpha complex and the Flood complex
     when landmarks L are set equal to the dataset X.clear
@@ -37,7 +37,7 @@ def test_vs_alpha_1(use_triton, batch_size, use_rand):
     X = X.to(DEVICE)
     L = L.to(DEVICE)
     num_rand = 20_000
-    points_per_edge = 125
+    points_per_edge = 130
     if use_rand:
         kwargs = {"num_rand": num_rand, "points_per_edge": None}
     else:


### PR DESCRIPTION
- when using random points for computing filtration values, are now converted to tuples before adding them to the out_complex dictionary (was cuda tensor, which were later on sent to cpu each on its own) 
- reuse existing simplex tree object from delaunay triangualtion instead of creating a new one
- landmarks argument is now checked for numbers.Integral instead of int