### PR TITLE
README.md fixes and Triton-non-availability handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 assets
 dist
 flooder.egg-info

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 The previous commands will install all dependencies, such as `torch`, `gudhi`, `numpy`, `fpsample` and `scipy`. Once installed, you can run our examples from within the top-level `flooder` folder (i.e., the directory created when doing `git clone`) via 
 
 ```bash
-PYTHONPATH=. python examples/example_01_cheese_3D.py
+PYTHONPATH=. python examples/example_01_cheese_3d.py
 ```
 
 Alternatively, you can also do a `pip install -e .` for a local [editable](https://setuptools.pypa.io/en/latest/userguide/development_mode.html) build. Note that the latter command will already install all required dependencies (so, there is no need to do a `pip install -r requirements.txt`).
@@ -120,7 +120,7 @@ for data in dataset:
 ## Related Projects
 
 If you are looking for fast implementations of (Vietoris-)Rips PH, see 
-[ripser](https://github.com/ripser/ripser), or the GPU-accelerated [ripser++](https://github.com/simonzhang00/ripser-plusplus), respectively. In addition [gudhi](https://pypi.org/project/gudhi/) supports, e.g., computing Alpha PH also on fairly large point clouds (see the `examples/example_01_cheese_3D.py` for a runtime comparison).
+[ripser](https://github.com/ripser/ripser), or the GPU-accelerated [ripser++](https://github.com/simonzhang00/ripser-plusplus), respectively. In addition [gudhi](https://pypi.org/project/gudhi/) supports, e.g., computing Alpha PH also on fairly large point clouds (see the `examples/example_01_cheese_3d.py` for a runtime comparison).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In the following example, we compute **Flood PH** on 2M points from a standard m
 
 ```python
 from flooder import (
-    generate_noisy_torus_points, 
+    generate_noisy_torus_points_3d, 
     flood_complex, 
     generate_landmarks)
 
@@ -81,7 +81,7 @@ DEVICE = "cuda"
 n_pts = 1_000_000  # Number of points to sample from torus
 n_lms = 1_000      # Number of landmarks for Flood complex
 
-pts = generate_noisy_torus_points(n_pts).to(DEVICE)
+pts = generate_noisy_torus_points_3d(n_pts).to(DEVICE)
 lms = generate_landmarks(pts, n_lms)
 
 stree = flood_complex(pts, lms, return_simplex_tree=True)

--- a/examples/example_01_cheese_3d.py
+++ b/examples/example_01_cheese_3d.py
@@ -49,9 +49,11 @@ def main():  # pylint: disable=missing-function-docstring
             )
 
             startt = time.perf_counter()
-            alpha = AlphaComplex(points).create_simplex_tree(
-                output_squared_values=False
-            )
+            alpha = AlphaComplex(points
+                                    .detach().to(device="cpu", dtype=torch.float64)
+                                    .contiguous()
+                                    .numpy()).create_simplex_tree(output_squared_values=False)
+                        
             t1 = time.perf_counter() - startt
 
             alpha.compute_persistence()

--- a/examples/example_01_cheese_3d.py
+++ b/examples/example_01_cheese_3d.py
@@ -49,11 +49,13 @@ def main():  # pylint: disable=missing-function-docstring
             )
 
             startt = time.perf_counter()
-            alpha = AlphaComplex(points
-                                    .detach().to(device="cpu", dtype=torch.float64)
-                                    .contiguous()
-                                    .numpy()).create_simplex_tree(output_squared_values=False)
-                        
+            alpha = AlphaComplex(
+                points.detach()
+                .to(device="cpu", dtype=torch.float64)
+                .contiguous()
+                .numpy()
+            ).create_simplex_tree(output_squared_values=False)
+
             t1 = time.perf_counter() - startt
 
             alpha.compute_persistence()

--- a/flooder/core.py
+++ b/flooder/core.py
@@ -20,8 +20,11 @@ from scipy.spatial import KDTree
 try:
     from .triton_kernels import compute_mask, compute_filtration, tl_dtypes_dict
     HAS_TRITON_KERNELS = True
+    TRITON_IMPORT_ERROR = None
 except Exception as e:
+    # triton import failed, so we cannot use triton kernels
     HAS_TRITON_KERNELS = False
+    TRITON_IMPORT_ERROR = e
 
 BLOCK_W = 512
 BLOCK_R = 16
@@ -93,7 +96,7 @@ def flood_complex(
     if use_triton and not HAS_TRITON_KERNELS:
         raise ImportError(
             "use_triton=True requested, but Triton kernels are not available in this environment."
-        )
+        ) from TRITON_IMPORT_ERROR
     if max_dimension is None:
         max_dimension = points.shape[1]
     if isinstance(landmarks, Integral):
@@ -106,14 +109,12 @@ def flood_complex(
         )
     if landmarks.dtype != points.dtype:
         raise RuntimeError(
-
-
             f"landmarks.dtype ({landmarks.dtype}) != points.device ({points.dtype})"
         )
     device = points.device
     dtype = points.dtype
 
-    if dtype not in tl_dtypes_dict:
+    if dtype not in (torch.float32, torch.float64):
         raise TypeError(f"dtype ({dtype}) not supported")
     if dtype is torch.float64:
         warnings.warn(
@@ -128,8 +129,10 @@ def flood_complex(
         kdtree = KDTree(np.asarray(points))
 
     stree = gudhi.DelaunayComplex(  # pylint: disable=no-member
-        landmarks
-    ).create_simplex_tree()
+        landmarks.detach()
+            .to(device="cpu", dtype=torch.float64)
+            .contiguous()
+            .numpy()).create_simplex_tree()
     out_complex = {}
 
     simplices = [[] for _ in range(max_dimension + 1)]

--- a/flooder/core.py
+++ b/flooder/core.py
@@ -18,7 +18,7 @@ from scipy.spatial import KDTree
 
 # catch triton import errors, so that users can still use CPU functionality
 try:
-    from .triton_kernels import compute_mask, compute_filtration, tl_dtypes_dict
+    from .triton_kernels import compute_mask, compute_filtration
     HAS_TRITON_KERNELS = True
     TRITON_IMPORT_ERROR = None
 except Exception as e:
@@ -129,10 +129,8 @@ def flood_complex(
         kdtree = KDTree(np.asarray(points))
 
     stree = gudhi.DelaunayComplex(  # pylint: disable=no-member
-        landmarks.detach()
-            .to(device="cpu", dtype=torch.float64)
-            .contiguous()
-            .numpy()).create_simplex_tree()
+        landmarks.detach().to(device="cpu", dtype=torch.float64).contiguous().numpy()
+    ).create_simplex_tree()
     out_complex = {}
 
     simplices = [[] for _ in range(max_dimension + 1)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ include = ["flooder"]
 
 [project]
 name = "flooder"
-version = "1.0.1"
+version = "1.0.2"
 description = "Flood complex PH"
 readme = "README.md"
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="flooder",
-    version="1.0",
+    version="1.0.2",
     description="Flood complex PH",
     author="Paolo Pellizzoni, Florian Graf, Martin Uray, Stefan Huber, Roland Kwitt",
     author_email="roland.kwitt@gmail.com",


### PR DESCRIPTION
Fixes in README.md and a more subtle issue in core.py where we handle the non-availability of triton; we were relying on the availability of `tl_dtypes_dict` but this is only available if triton import actually works (which led to the following [issue](https://github.com/plus-rkwitt/flooder/issues/38#issue-4871186771))